### PR TITLE
Test environment variables set correctly

### DIFF
--- a/.github/workflows/test_2004.yml
+++ b/.github/workflows/test_2004.yml
@@ -9,12 +9,12 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
-      - name: Check kernel version
+      - name: Print kernel version
         run: uname -mr
 
-      - name: Check OS version
+      - name: Print OS version
         run: lsb_release -a
 
       - name: Print environment variables

--- a/.github/workflows/test_2004.yml
+++ b/.github/workflows/test_2004.yml
@@ -45,5 +45,4 @@ jobs:
         run: sudo apt-get update
 
       - name: Check filesystem
-        continue-on-error: true
-        run: sudo fsck -nf
+        run: sudo fsck -nf || [ $? -eq 4 ]

--- a/.github/workflows/test_2004.yml
+++ b/.github/workflows/test_2004.yml
@@ -23,6 +23,24 @@ jobs:
       - name: Print PATH
         run: echo $PATH
 
+      - name: Verify that has more than 100 environment variables
+        run: |
+          count=$(env | wc -l)
+          if [ "$count" -lt 100 ]; then
+            echo "Environment has $count variables, expected at least 100"
+            exit 1
+          fi
+
+      - name: Verify that environment variables are set correctly
+        run: |
+          source ./test-helpers.sh
+          expect "$HOME" "/home/runner"
+          expect "$RUNNER_ARCH" "X64"
+          expect "$ImageOS" "ubuntu20"
+          expect "$ANDROID_HOME" "/usr/local/lib/android/sdk"
+          expect_path_variable "/home/runner/.cargo/bin"
+          expect_path_variable "/home/runner/.config/composer/vendor/bin"
+
       - name: Try to update apt-get
         run: sudo apt-get update
 

--- a/.github/workflows/test_2204.yml
+++ b/.github/workflows/test_2204.yml
@@ -9,12 +9,12 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
-      - name: Check kernel version
+      - name: Print kernel version
         run: uname -mr
 
-      - name: Check OS version
+      - name: Print OS version
         run: lsb_release -a
 
       - name: Print environment variables

--- a/.github/workflows/test_2204.yml
+++ b/.github/workflows/test_2204.yml
@@ -45,5 +45,4 @@ jobs:
         run: sudo apt-get update
 
       - name: Check filesystem
-        continue-on-error: true
-        run: sudo fsck -nf
+        run: sudo fsck -nf || [ $? -eq 4 ]

--- a/.github/workflows/test_2204.yml
+++ b/.github/workflows/test_2204.yml
@@ -23,6 +23,24 @@ jobs:
       - name: Print PATH
         run: echo $PATH
 
+      - name: Verify that has more than 100 environment variables
+        run: |
+          count=$(env | wc -l)
+          if [ "$count" -lt 100 ]; then
+            echo "Environment has $count variables, expected at least 100"
+            exit 1
+          fi
+
+      - name: Verify that environment variables are set correctly
+        run: |
+          source ./test-helpers.sh
+          expect "$HOME" "/home/runner"
+          expect "$RUNNER_ARCH" "X64"
+          expect "$ImageOS" "ubuntu22"
+          expect "$ANDROID_HOME" "/usr/local/lib/android/sdk"
+          expect_path_variable "/home/runner/.cargo/bin"
+          expect_path_variable "/home/runner/.config/composer/vendor/bin"
+
       - name: Try to update apt-get
         run: sudo apt-get update
 

--- a/test-helpers.sh
+++ b/test-helpers.sh
@@ -1,0 +1,6 @@
+#!/bin/bash -e
+
+expect () { [ "$1" = "$2" ] || { echo "actual: $1 expected: $2"; exit 1; }; }
+
+expect_path_variable () { [[ ":$PATH:" == *":$1:"* ]] || { echo "expected to have '$1' in '$PATH'"; exit 1; }; }
+


### PR DESCRIPTION
### Update outdated workflow and rename steps

### Test environment variables set correctly

I recently deployed a bug that overwrite whole /etc/environment file at
https://github.com/ubicloud/ubicloud/commit/703818db8bb6d500ce65ecd3893469c2f683c40e.
This led to failures in loading environment variables that required to
run most of the workflow jobs. We noticed it after 5 hours due a
customer reported some failures. We might have detected it with GitHub
Actions E2E tests, if they had high coverage. Assuming all are set
correctly, we can expect having more than 100 environment variables

### Test exit code of filesystem check is 4
Previously, we was checking it manually, so the CI would always succeed
regardless if the expected behavior was demonstrated. We can automate
this check by checking the exit code of the filesystem check.  If the
exit code is 4, the filesystem check failed as expected. However, it
doesn't contain any fatal errors that could cause failures.