### PR TITLE
Add tests for Ubuntu 24 runners

### DIFF
--- a/.github/workflows/test_2404.yml
+++ b/.github/workflows/test_2404.yml
@@ -1,0 +1,48 @@
+name: Test ubuntu-2404
+
+on:
+  workflow_dispatch:
+
+jobs:
+  test:
+    runs-on: ubicloud-standard-2-ubuntu-2404
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Print kernel version
+        run: uname -mr
+
+      - name: Print OS version
+        run: lsb_release -a
+
+      - name: Print environment variables
+        run: printenv
+
+      - name: Print PATH
+        run: echo $PATH
+
+      - name: Verify that has more than 100 environment variables
+        run: |
+          count=$(env | wc -l)
+          if [ "$count" -lt 100 ]; then
+            echo "Environment has $count variables, expected at least 100"
+            exit 1
+          fi
+
+      - name: Verify that environment variables are set correctly
+        run: |
+          source ./test-helpers.sh
+          expect "$HOME" "/home/runner"
+          expect "$RUNNER_ARCH" "X64"
+          expect "$ImageOS" "ubuntu24"
+          expect "$ANDROID_HOME" "/usr/local/lib/android/sdk"
+          expect_path_variable "/home/runner/.cargo/bin"
+          expect_path_variable "/home/runner/.config/composer/vendor/bin"
+
+      - name: Try to update apt-get
+        run: sudo apt-get update
+
+      - name: Check filesystem
+        run: sudo fsck -nf || [ $? -eq 4 ]


### PR DESCRIPTION
We enabled Ubuntu 24 runners at
https://github.com/ubicloud/ubicloud/pull/1838. We need to test them E2E.

Successful run: https://github.com/enescakir/github-e2e-test-workflows/actions/runs/10365907031