### PR TITLE
Check the internet connectivity of docker containers

### DIFF
--- a/.github/workflows/test_2004.yml
+++ b/.github/workflows/test_2004.yml
@@ -4,45 +4,8 @@ on:
   workflow_dispatch:
 
 jobs:
-  test:
-    runs-on: ubicloud-standard-2-ubuntu-2004
-
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-
-      - name: Print kernel version
-        run: uname -mr
-
-      - name: Print OS version
-        run: lsb_release -a
-
-      - name: Print environment variables
-        run: printenv
-
-      - name: Print PATH
-        run: echo $PATH
-
-      - name: Verify that has more than 100 environment variables
-        run: |
-          count=$(env | wc -l)
-          if [ "$count" -lt 100 ]; then
-            echo "Environment has $count variables, expected at least 100"
-            exit 1
-          fi
-
-      - name: Verify that environment variables are set correctly
-        run: |
-          source ./test-helpers.sh
-          expect "$HOME" "/home/runner"
-          expect "$RUNNER_ARCH" "X64"
-          expect "$ImageOS" "ubuntu20"
-          expect "$ANDROID_HOME" "/usr/local/lib/android/sdk"
-          expect_path_variable "/home/runner/.cargo/bin"
-          expect_path_variable "/home/runner/.config/composer/vendor/bin"
-
-      - name: Try to update apt-get
-        run: sudo apt-get update
-
-      - name: Check filesystem
-        run: sudo fsck -nf || [ $? -eq 4 ]
+  test_image:
+    uses: ./.github/workflows/test_image.yml
+    with:
+      runner: ubicloud-standard-2-ubuntu-2004
+      image_os: ubuntu20

--- a/.github/workflows/test_2204.yml
+++ b/.github/workflows/test_2204.yml
@@ -4,45 +4,8 @@ on:
   workflow_dispatch:
 
 jobs:
-  test:
-    runs-on: ubicloud-standard-2-ubuntu-2204
-
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-
-      - name: Print kernel version
-        run: uname -mr
-
-      - name: Print OS version
-        run: lsb_release -a
-
-      - name: Print environment variables
-        run: printenv
-
-      - name: Print PATH
-        run: echo $PATH
-
-      - name: Verify that has more than 100 environment variables
-        run: |
-          count=$(env | wc -l)
-          if [ "$count" -lt 100 ]; then
-            echo "Environment has $count variables, expected at least 100"
-            exit 1
-          fi
-
-      - name: Verify that environment variables are set correctly
-        run: |
-          source ./test-helpers.sh
-          expect "$HOME" "/home/runner"
-          expect "$RUNNER_ARCH" "X64"
-          expect "$ImageOS" "ubuntu22"
-          expect "$ANDROID_HOME" "/usr/local/lib/android/sdk"
-          expect_path_variable "/home/runner/.cargo/bin"
-          expect_path_variable "/home/runner/.config/composer/vendor/bin"
-
-      - name: Try to update apt-get
-        run: sudo apt-get update
-
-      - name: Check filesystem
-        run: sudo fsck -nf || [ $? -eq 4 ]
+  test_image:
+    uses: ./.github/workflows/test_image.yml
+    with:
+      runner: ubicloud-standard-2-ubuntu-2204
+      image_os: ubuntu22

--- a/.github/workflows/test_2404.yml
+++ b/.github/workflows/test_2404.yml
@@ -4,45 +4,8 @@ on:
   workflow_dispatch:
 
 jobs:
-  test:
-    runs-on: ubicloud-standard-2-ubuntu-2404
-
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-
-      - name: Print kernel version
-        run: uname -mr
-
-      - name: Print OS version
-        run: lsb_release -a
-
-      - name: Print environment variables
-        run: printenv
-
-      - name: Print PATH
-        run: echo $PATH
-
-      - name: Verify that has more than 100 environment variables
-        run: |
-          count=$(env | wc -l)
-          if [ "$count" -lt 100 ]; then
-            echo "Environment has $count variables, expected at least 100"
-            exit 1
-          fi
-
-      - name: Verify that environment variables are set correctly
-        run: |
-          source ./test-helpers.sh
-          expect "$HOME" "/home/runner"
-          expect "$RUNNER_ARCH" "X64"
-          expect "$ImageOS" "ubuntu24"
-          expect "$ANDROID_HOME" "/usr/local/lib/android/sdk"
-          expect_path_variable "/home/runner/.cargo/bin"
-          expect_path_variable "/home/runner/.config/composer/vendor/bin"
-
-      - name: Try to update apt-get
-        run: sudo apt-get update
-
-      - name: Check filesystem
-        run: sudo fsck -nf || [ $? -eq 4 ]
+  test_image:
+    uses: ./.github/workflows/test_image.yml
+    with:
+      runner: ubicloud-standard-2-ubuntu-2404
+      image_os: ubuntu24

--- a/.github/workflows/test_image.yml
+++ b/.github/workflows/test_image.yml
@@ -1,0 +1,55 @@
+name: Test core functionality of image
+
+on:
+  workflow_call:
+    inputs:
+      runner:
+        required: true
+        type: string
+      image_os:
+        required: true
+        type: string
+
+jobs:
+  test:
+    name: ${{ inputs.image_os }}
+    runs-on: ${{ inputs.runner }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Print kernel version
+        run: uname -mr
+
+      - name: Print OS version
+        run: lsb_release -a
+
+      - name: Print environment variables
+        run: printenv
+
+      - name: Print PATH
+        run: echo $PATH
+
+      - name: Verify that has more than 100 environment variables
+        run: |
+          count=$(env | wc -l)
+          if [ "$count" -lt 100 ]; then
+            echo "Environment has $count variables, expected at least 100"
+            exit 1
+          fi
+
+      - name: Verify that environment variables are set correctly
+        run: |
+          source ./test-helpers.sh
+          expect "$HOME" "/home/runner"
+          expect "$RUNNER_ARCH" "X64"
+          expect "$ImageOS" "${{ inputs.image_os }}"
+          expect "$ANDROID_HOME" "/usr/local/lib/android/sdk"
+          expect_path_variable "/home/runner/.cargo/bin"
+          expect_path_variable "/home/runner/.config/composer/vendor/bin"
+
+      - name: Try to update apt-get
+        run: sudo apt-get update
+
+      - name: Check filesystem
+        run: sudo fsck -nf || [ $? -eq 4 ]

--- a/.github/workflows/test_image.yml
+++ b/.github/workflows/test_image.yml
@@ -53,3 +53,6 @@ jobs:
 
       - name: Check filesystem
         run: sudo fsck -nf || [ $? -eq 4 ]
+      
+      - name: Check docker internet connectivity
+        run: docker run alpine ping -c 2 google.com


### PR DESCRIPTION
### Extract common image tests to a reusable workflow

We run similar tests on Ubuntu 20, 22, and 24 images. By making these reusable, we can make our workflow more maintainable.

### Check the internet connectivity of docker containers

The DNS resolution within Docker containers highly relies on the network configuration of vm. We've made specific adjustments for this. To ensure there's no regression, it's important that we test it.