### PR TITLE
Add version to caches

### DIFF
--- a/.github/workflows/test_restore_cache.yml
+++ b/.github/workflows/test_restore_cache.yml
@@ -17,9 +17,15 @@ jobs:
   test:
     name: ${{ inputs.image_os }} ${{ inputs.arch }} restore cache
     runs-on: ${{ inputs.runner }}
+    env:
+      CACHE_VERSION: ${{ inputs.runner }}-${{ github.run_id }}-${{ github.run_attempt }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+
+      - name: Create version file trigger fresh cache
+        run: |
+          echo "Cache version: ${{ env.CACHE_VERSION }}" >> cache-version.txt
 
       - name: Setup python with cache
         id: setup-python
@@ -27,6 +33,9 @@ jobs:
         with:
           python-version: '3.9'
           cache: 'pip'
+          cache-dependency-path: |
+            python/requirements.txt
+            cache-version.txt
 
       - name: Error if cache doesn't hit for setup-python
         if: steps.setup-python.outputs.cache-hit == 'false'
@@ -39,7 +48,9 @@ jobs:
         id: setup-go
         with:
           go-version: '1.22'
-          cache-dependency-path: go/go.sum
+          cache-dependency-path: |
+            go/go.sum
+            cache-version.txt
 
       - name: Error if cache doesn't hit for setup-go
         if: steps.setup-go.outputs.cache-hit == 'false'
@@ -55,6 +66,7 @@ jobs:
         with:
           ruby-version: '3.2.6'
           bundler-cache: true
+          cache-version: ${{ env.CACHE_VERSION }}
 
       - name: Error if cache doesn't hit for setup-ruby
         if: steps.setup-ruby.outputs.cache-hit == 'false'
@@ -65,6 +77,8 @@ jobs:
       - name: Cache Rust dependencies
         id: rust-cache
         uses: Swatinem/rust-cache@v2
+        with:
+          prefix-key: ${{ env.CACHE_VERSION }} 
 
       - name: Error if cache doesn't hit for rust-cache
         if: steps.rust-cache.outputs.cache-hit == 'false'
@@ -79,7 +93,7 @@ jobs:
           path: |
             myfolder
             myfolder2
-          key: cached_folders
+          key: cached_folders_${{ env.CACHE_VERSION }}
 
       - name: Error if cache doesn't hit for restore-file
         if: steps.restore-file.outputs.cache-hit == 'false'

--- a/.github/workflows/test_save_cache.yml
+++ b/.github/workflows/test_save_cache.yml
@@ -17,15 +17,24 @@ jobs:
   test:
     name: ${{ inputs.image_os }} ${{ inputs.arch }} save cache
     runs-on: ${{ inputs.runner }}
+    env:
+      CACHE_VERSION: ${{ inputs.runner }}-${{ github.run_id }}-${{ github.run_attempt }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+
+      - name: Create version file trigger fresh cache
+        run: |
+          echo "Cache version: ${{ env.CACHE_VERSION }}" >> cache-version.txt
 
       - name: Setup python
         uses: actions/setup-python@v5
         with:
           python-version: '3.9'
           cache: 'pip'
+          cache-dependency-path: |
+            python/requirements.txt
+            cache-version.txt
 
       - run: pip install -r python/requirements.txt
 
@@ -33,7 +42,9 @@ jobs:
         uses: actions/setup-go@v5
         with:
           go-version: '1.22'
-          cache-dependency-path: go/go.sum
+          cache-dependency-path: |
+            go/go.sum
+            cache-version.txt
 
       - name: Setup Ruby
         uses: ruby/setup-ruby@v1
@@ -42,9 +53,12 @@ jobs:
         with:
           ruby-version: '3.2.6'
           bundler-cache: true
+          cache-version: ${{ env.CACHE_VERSION }}
 
       - name: Cache Rust dependencies
         uses: Swatinem/rust-cache@v2
+        with:
+          prefix-key: ${{ env.CACHE_VERSION }} 
 
       - name: Build Rust project
         run: cargo build
@@ -63,7 +77,7 @@ jobs:
           path: |
             myfolder
             myfolder2
-          key: cached_folders
+          key: cached_folders_${{ env.CACHE_VERSION }}
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3


### PR DESCRIPTION
Since we setup E2E tests environment from scratch every time, it's not necessary. But when we run tests in non-E2E environment, we need to add version to caches to avoid conflicts.

Also if the both runner type are running in the same time, their caches also will be conflicted in E2E environment too.