### PR TITLE
Add workflow ID to run name

### DIFF
--- a/.github/workflows/test_2004.yml
+++ b/.github/workflows/test_2004.yml
@@ -1,4 +1,5 @@
 name: Test ubuntu-2004
+run-name: ubuntu-2004 ${{ inputs.arch }} ${{ inputs.triggered_by }}
 
 on:
   workflow_dispatch:
@@ -8,6 +9,9 @@ on:
         type: choice
         options: [x64, arm64]
         default: x64
+      triggered_by:
+        required: false
+        type: string
 
 jobs:
   test_image:

--- a/.github/workflows/test_2204.yml
+++ b/.github/workflows/test_2204.yml
@@ -1,4 +1,5 @@
 name: Test ubuntu-2204
+run-name: ubuntu-2204 ${{ inputs.arch }} ${{ inputs.triggered_by }}
 
 on:
   workflow_dispatch:
@@ -8,6 +9,9 @@ on:
         type: choice
         options: [x64, arm64]
         default: x64
+      triggered_by:
+        required: false
+        type: string
 
 jobs:
   test_image:

--- a/.github/workflows/test_2404.yml
+++ b/.github/workflows/test_2404.yml
@@ -1,4 +1,5 @@
 name: Test ubuntu-2404
+run-name: ubuntu-2404 ${{ inputs.arch }} ${{ inputs.triggered_by }}
 
 on:
   workflow_dispatch:
@@ -8,6 +9,9 @@ on:
         type: choice
         options: [x64, arm64]
         default: x64
+      triggered_by:
+        required: false
+        type: string
 
 jobs:
   test_image:


### PR DESCRIPTION
Since we run e2e tests every hour, it's hard to tell which run is which. This PR adds the workflow ID to the run name to make it easier to identify them.