### PR TITLE
Cancel previously queued jobs

### DIFF
--- a/.github/workflows/test_2004.yml
+++ b/.github/workflows/test_2004.yml
@@ -13,6 +13,10 @@ on:
         required: false
         type: string
 
+concurrency:
+  group: ubuntu-2004-${{ inputs.arch }}
+  cancel-in-progress: true
+
 jobs:
   test_image:
     uses: ./.github/workflows/test_all.yml

--- a/.github/workflows/test_2204.yml
+++ b/.github/workflows/test_2204.yml
@@ -13,6 +13,10 @@ on:
         required: false
         type: string
 
+concurrency:
+  group: ubuntu-2204-${{ inputs.arch }}
+  cancel-in-progress: true
+
 jobs:
   test_image:
     uses: ./.github/workflows/test_all.yml

--- a/.github/workflows/test_2404.yml
+++ b/.github/workflows/test_2404.yml
@@ -13,6 +13,10 @@ on:
         required: false
         type: string
 
+concurrency:
+  group: ubuntu-2404-${{ inputs.arch }}
+  cancel-in-progress: true
+
 jobs:
   test_image:
     uses: ./.github/workflows/test_all.yml


### PR DESCRIPTION
We trigger workflow jobs in E2E tests. If the E2E tests exit unexpectedly due to reasons like a hard timeout, the triggered workflow jobs remain in the queue. When a new run of E2E tests provisions some runners, they pick up the old jobs, causing the newly triggered jobs to get stuck in the queue. We should keep only the latest job and cancel the rest.