### PR TITLE
Add step to print cache proxy logs

### DIFF
--- a/.github/workflows/test_restore_cache.yml
+++ b/.github/workflows/test_restore_cache.yml
@@ -103,3 +103,7 @@ jobs:
         run: |
           echo "Cache didn't hit for build-docker"
           exit 1
+
+      - name: Print cache proxy log
+        run: sudo cat /var/log/cacheproxy.log
+        if: always()

--- a/.github/workflows/test_save_cache.yml
+++ b/.github/workflows/test_save_cache.yml
@@ -74,3 +74,7 @@ jobs:
           context: ./docker
           push: false
           cache-to: type=gha,mode=max
+
+      - name: Print cache proxy log
+        run: sudo cat /var/log/cacheproxy.log
+        if: always()


### PR DESCRIPTION
Printing the cache proxy logs even if any steps above it fails, so we can investigate issues happening with cache operations better.