### PR TITLE
Do not run cache tests for Ubuntu 20

### DIFF
--- a/.github/workflows/test_all.yml
+++ b/.github/workflows/test_all.yml
@@ -22,6 +22,7 @@ jobs:
       arch: ${{ inputs.arch }}
 
   test_save_cache:
+    if: inputs.image_os != 'ubuntu20'
     uses: ./.github/workflows/test_save_cache.yml
     with:
       runner: ${{ inputs.runner }}
@@ -29,6 +30,7 @@ jobs:
       arch: ${{ inputs.arch }}
 
   test_restore_cache:
+    if: inputs.image_os != 'ubuntu20'
     needs: test_save_cache
     uses: ./.github/workflows/test_restore_cache.yml
     with:


### PR DESCRIPTION
GitHub started to depracate Ubuntu 20 runners.

ruby/setup-ruby just removed support for them

https://github.com/ruby/setup-ruby/commit/2e007403fc1ec238429ecaa57af6f22f019cc135

Other setup actions also started to remove support for it. So it's good to not run cache suites for Ubuntu 20.